### PR TITLE
Fixed UnsubscribeArticleCreation to delete unsubscribing observer

### DIFF
--- a/service/article_service.go
+++ b/service/article_service.go
@@ -89,8 +89,8 @@ func (svc *ArticleService) SubscribeArticleCreation() *ArticleServiceObserver {
 func (svc *ArticleService) UnsubscribeArticleCreation(observer *ArticleServiceObserver) {
 	svc.mutex.Lock()
 	close(observer.CreationStream)
-	for i, sub := range svc.articleCreationObservers {
-		if sub == observer {
+	for i, obs := range svc.articleCreationObservers {
+		if obs == observer {
 			// Remove from slice. Copy last element to the position of to be deleted element and truncate slice.
 			svc.articleCreationObservers[i] = svc.articleCreationObservers[len(svc.articleCreationObservers)-1]
 			svc.articleCreationObservers[len(svc.articleCreationObservers)-1] = nil

--- a/service/article_service.go
+++ b/service/article_service.go
@@ -89,13 +89,15 @@ func (svc *ArticleService) SubscribeArticleCreation() *ArticleServiceObserver {
 func (svc *ArticleService) UnsubscribeArticleCreation(observer *ArticleServiceObserver) {
 	svc.mutex.Lock()
 	close(observer.CreationStream)
-	j := 0
-	for _, entry := range svc.articleCreationObservers {
-		if entry == observer {
-			svc.articleCreationObservers[j] = entry
+	for i, sub := range svc.articleCreationObservers {
+		if sub == observer {
+			// Remove from slice. Copy last element to the position of to be deleted element and truncate slice.
+			svc.articleCreationObservers[i] = svc.articleCreationObservers[len(svc.articleCreationObservers)-1]
+			svc.articleCreationObservers[len(svc.articleCreationObservers)-1] = nil
+			svc.articleCreationObservers = svc.articleCreationObservers[:len(svc.articleCreationObservers)-1]
+			break
 		}
 	}
-	svc.articleCreationObservers = svc.articleCreationObservers[:j]
 	svc.mutex.Unlock()
 }
 


### PR DESCRIPTION
Fixed UnsubscribeArticleCreation to delete unsubscribing observer from observers slice. Before an unsubscribe would wipe all observers. 